### PR TITLE
Skip global tracer for testing and inside handlers

### DIFF
--- a/tracing/handlers/tracing_handlers.go
+++ b/tracing/handlers/tracing_handlers.go
@@ -64,7 +64,7 @@ func (f *openTracingHandler) ServeHTTP(writer http.ResponseWriter, req *http.Req
 	var serverSpan opentracing.Span
 
 	if wireContext != nil {
-		serverSpan = opentracing.StartSpan(
+		serverSpan = f.tracer.StartSpan(
 			f.spanName,
 			ext.RPCServerOption(wireContext))
 		defer serverSpan.Finish()

--- a/tracing/jaeger/jaeger_init.go
+++ b/tracing/jaeger/jaeger_init.go
@@ -12,12 +12,12 @@ import (
 
 // Init initializes things required for use of Jaeger for open tracing.
 // For details about the configuration options see https://github.com/jaegertracing/jaeger-client-go#environment-variables
-func Init() (io.Closer, error) {
+func Init() (opentracing.Tracer, io.Closer, error) {
 	cfg, err := jaegercfg.FromEnv()
 	if err != nil {
 		// parsing errors might happen here, such as when we get a string where we expect a number
 		log.Printf("Could not parse Jaeger env vars: %s", err.Error())
-		return nil, err
+		return nil, nil, err
 	}
 
 	jLogger := jaegerlog.StdLogger
@@ -25,9 +25,8 @@ func Init() (io.Closer, error) {
 	tracer, closer, err := cfg.NewTracer(jaegercfg.Logger(jLogger))
 	if err != nil {
 		log.Printf("Could not initialize jaeger tracer: %s", err.Error())
-		return nil, err
+		return nil, nil, err
 	}
 	log.Printf("JaegerInit, ServiceName: %s", cfg.ServiceName)
-	opentracing.SetGlobalTracer(tracer)
-	return closer, nil
+	return tracer, closer, nil
 }


### PR DESCRIPTION
Inside the tracing handler it was using the global handler when it should have been using the provided handler. Skip all global handler use to make sure the tracer specific handler really works.